### PR TITLE
Working with SOAP binding

### DIFF
--- a/.extlib/simplesamlphp/lib/SimpleSAML/Session.php
+++ b/.extlib/simplesamlphp/lib/SimpleSAML/Session.php
@@ -736,11 +736,7 @@ class Session implements \Serializable, Utils\ClearableState
         assert(isset($this->authData[$authority]));
 
         if (empty($this->authData[$authority]['LogoutHandlers'])) {
-            if (empty($this->authData[$authority]['Attributes']['username'][0])) {
-                return;
-            } else {
-                call_user_func(['\auth_saml2\api', 'logout_from_idp_back_channel'], $this->authData[$authority]['Attributes']['username'][0], $this->sessionId);
-            }
+            return;
         }
         foreach ($this->authData[$authority]['LogoutHandlers'] as $handler) {
             // verify that the logout handler is a valid function

--- a/.extlib/simplesamlphp/modules/saml/www/sp/saml2-logout.php
+++ b/.extlib/simplesamlphp/modules/saml/www/sp/saml2-logout.php
@@ -130,7 +130,6 @@ if ($message instanceof \SAML2\LogoutResponse) {
     $dst = $idpMetadata->getEndpointPrioritizedByBinding(
         'SingleLogoutService',
         [
-            \SAML2\Constants::BINDING_SOAP,
             \SAML2\Constants::BINDING_HTTP_REDIRECT,
             \SAML2\Constants::BINDING_HTTP_POST
         ]
@@ -144,10 +143,7 @@ if ($message instanceof \SAML2\LogoutResponse) {
             $dst = $dst['Location'];
         }
         $binding->setDestination($dst);
-    } else {
-        $lr->setDestination($dst['Location']);
     }
-
     $binding->send($lr);
 } else {
     throw new \SimpleSAML\Error\BadRequest('Unknown message received on logout endpoint: ' . get_class($message));

--- a/classes/auth.php
+++ b/classes/auth.php
@@ -726,6 +726,16 @@ class auth extends \auth_plugin_base {
         $USER->site = $CFG->wwwroot;
         set_moodle_cookie($USER->username);
 
+        // Backchannel soap logout : registers the  back channel logout handler
+        // and stores the moodle session_id to be able to kill it when receiving a soap logout request
+        $moodle_session_id = session_id();
+        $saml_session = \SimpleSAML\Session::getSessionFromRequest();
+        //registers SOAP logout Handler in the session
+        $saml_session->registerLogoutHandler($this->spname, '\auth_saml2\api', 'logout_from_idp_back_channel');
+        $saml_session->moodle_session_id = $moodle_session_id;
+        $saml_session_handler = \SimpleSAML\SessionHandler::getSessionHandler();
+        $saml_session_handler->saveSession($saml_session);
+
         $wantsurl = core_login_get_return_url();
         // If we are not on the page we want, then redirect to it (unless this is CLI).
         if ( qualified_me() !== false && qualified_me() !== $wantsurl ) {

--- a/locallib.php
+++ b/locallib.php
@@ -62,7 +62,7 @@ function auth_saml2_get_sp_metadata() {
 
     $slosvcdefault = array(
         SAML2\Constants::BINDING_HTTP_REDIRECT,
-        // SAML2\Constants::BINDING_SOAP, // TODO untested.
+        SAML2\Constants::BINDING_SOAP,
     );
 
     $slob = $spconfig->getArray('SingleLogoutServiceBinding', $slosvcdefault);


### PR DESCRIPTION
Hello,

This is our take at the SOAP binding issue for the auth_saml2 plugin.
We strongly based it on your proposal and payed attention to the reviewers comment. Doing so we tried to limitate any changes taking place in .exitlib/ as much as possible.
In this regard we had to more or less duplicate some code from lib/Message.php to classes/api.php for the logout handling.
Should we edit .extlib/simplesamphp/lib/SimpleSAML/Session.php #L154 to pass $this as a second argument to call_user_func, we wouldn't have to bother about retrieving the session in logout_from_idp_back_channel() and the code would be much dryer.
Depending on how the priorities are set on that subject there should be a small change or no changes at all for this solution to work without killing every session for the user but only the one targeted by the SAML logout

Best regards,
Amaury from CBlue.